### PR TITLE
Added password hashing client-side

### DIFF
--- a/src/main/java/net/testudobank/User.java
+++ b/src/main/java/net/testudobank/User.java
@@ -7,15 +7,44 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
 @ToString(onlyExplicitlyIncluded = true)
 public class User {
+
+  //// Password Helper Methods ////
+  public static String toHexString(byte[] hashBytes) {
+    // Convert byte array into signum representation
+    BigInteger number = new BigInteger(1, hashBytes);
+    // Convert message digest into hex value
+    StringBuilder hexString = new StringBuilder(number.toString(16));
+    // Pad with leading zeros
+    while (hexString.length() < 64)
+    {
+        hexString.insert(0, '0');
+    }
+    return hexString.toString();
+  }
   //// General Customer Fields ////
 
   @Setter @Getter @ToString.Include
 	private String username;
 
-  @Setter @Getter @ToString.Include
+  @Getter @ToString.Include
 	private String password;
+
+  public void setPassword(String password) {
+    try {
+      MessageDigest hasher = MessageDigest.getInstance("SHA-256");
+      this.password = toHexString(hasher.digest(password.getBytes(StandardCharsets.UTF_8)));
+    }
+    catch(NoSuchAlgorithmException e) {
+      this.password = password;
+    }
+  }
 
   @Setter @Getter
   private String firstName;


### PR DESCRIPTION
# File Changes
## MVCController.java
### toHexString(byte[] inputHash)
Method to convert a list of bytes (from the MessageDigest hasher) into a usable string

### hasAuthenticCredentials(User user)
Method to determine if the listed password for a User is equivalent to the password submitted: returns true if the credentials submitted are valid and false if not.

### Other methods
Replaced all user.getPassword().equals(userPassword) checks with calls to hasAuthenticCredentials(user) calls and made the formatting consistent: all contain !hasAuthenticCredentials instead of a mix between !user.getPassword().equals(userPassword) and user.getPassword().equals(userPassword) == false

## TestudoBankRepository.java
### toHexString(byte[] inputHash)
Method to convert a list of bytes (from the MessageDigest hasher) into a usable string

### getHashedCustomerPassword(JdbcTemplate jdbcTemplate, String customerID)
Gets the listed password for the requested user, hashes it, and returns it as a usable string via toHexString().

## User.java
### toHexString(byte[] inputHash)
Method to convert a list of bytes (from the MessageDigest hasher) into a usable string

### setPassword(String password)
Overrides the password setter method to set the instance field to the hashed version of the password passed into the method.

# Intent
In order to secure testudo bank, we need to prevent plaintext passwords from being stored as much as possible. Since we still need access to the cleartext passwords for debugging purposes, we can't remove them from the database entirely. Instead, my strategy was to, whenever the passwords are pulled from the database, hash them. This simulates the level of security implied by simply not storing cleartext passwords in the first place.